### PR TITLE
Confluence: Add parameter for version of page

### DIFF
--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -107,6 +107,7 @@ class Bamboo(AtlassianRestAPI):
         :param issue_key:
         :param start_index:
         :param max_results:
+        :param include_all_states:
         :return:
         """
         resource = "result"
@@ -129,7 +130,7 @@ class Bamboo(AtlassianRestAPI):
                                    elements_key='results', element_key='result', label=label, **params)
 
     def latest_results(self, expand=None, favourite=False, clover_enabled=False, label=None, issue_key=None,
-                       start_index=0, max_results=25):
+                       start_index=0, max_results=25, include_all_states=False):
         """
         Get latest Results
         :param expand:
@@ -139,13 +140,14 @@ class Bamboo(AtlassianRestAPI):
         :param issue_key:
         :param start_index:
         :param max_results:
+        :param include_all_states:
         :return:
         """
         return self.results(expand=expand, favourite=favourite, clover_enabled=clover_enabled,
-                            label=label, issue_key=issue_key, start_index=start_index, max_results=max_results)
+                            label=label, issue_key=issue_key, start_index=start_index, max_results=max_results, include_all_states=include_all_states)
 
     def project_latest_results(self, project_key, expand=None, favourite=False, clover_enabled=False, label=None,
-                               issue_key=None, start_index=0, max_results=25):
+                               issue_key=None, start_index=0, max_results=25, include_all_states=False):
         """
         Get latest Project Results
         :param project_key:
@@ -156,13 +158,14 @@ class Bamboo(AtlassianRestAPI):
         :param issue_key:
         :param start_index:
         :param max_results:
+        :param include_all_states:
         :return:
         """
         return self.results(project_key, expand=expand, favourite=favourite, clover_enabled=clover_enabled,
-                            label=label, issue_key=issue_key, start_index=start_index, max_results=max_results)
+                            label=label, issue_key=issue_key, start_index=start_index, max_results=max_results, include_all_states=include_all_states)
 
     def plan_results(self, project_key, plan_key, expand=None, favourite=False, clover_enabled=False, label=None,
-                     issue_key=None, start_index=0, max_results=25):
+                     issue_key=None, start_index=0, max_results=25, include_all_states=False):
         """
         Get Plan results
         :param project_key:
@@ -174,12 +177,13 @@ class Bamboo(AtlassianRestAPI):
         :param issue_key:
         :param start_index:
         :param max_results:
+        :param include_all_states:
         :return:
         """
         return self.results(project_key, plan_key, expand=expand, favourite=favourite, clover_enabled=clover_enabled,
-                            label=label, issue_key=issue_key, start_index=start_index, max_results=max_results)
+                            label=label, issue_key=issue_key, start_index=start_index, max_results=max_results, include_all_states=include_all_states)
 
-    def build_result(self, build_key, expand=None):
+    def build_result(self, build_key, expand=None, include_all_states=False):
         """
         Returns details of a specific build result
         :param expand: expands build result details on request. Possible values are: artifacts, comments, labels,
@@ -192,22 +196,23 @@ class Bamboo(AtlassianRestAPI):
             int(build_key.split('-')[-1])
             resource = "result/{}".format(build_key)
             return self.base_list_call(resource, expand, favourite=False, clover_enabled=False,
-                                       start_index=0, max_results=25)
+                                       start_index=0, max_results=25, include_all_states=include_all_states)
         except ValueError:
             raise ValueError('The key "{}" does not correspond to a build result'.format(build_key))
 
-    def build_latest_result(self, plan_key, expand=None):
+    def build_latest_result(self, plan_key, expand=None, include_all_states=False):
         """
         Returns details of a latest build result
         :param expand: expands build result details on request. Possible values are: artifacts, comments, labels,
         Jira Issues, stages. stages expand is available only for top level plans. It allows to drill down to job results
         using stages.stage.results.result. All expand parameters should contain results.result prefix.
         :param plan_key: Should be in the form XX-YY[-ZZ]
+        :param include_all_states:
         """
         try:
             resource = "result/{}/latest.json".format(plan_key)
             return self.base_list_call(resource, expand, favourite=False, clover_enabled=False,
-                                       start_index=0, max_results=25)
+                                       start_index=0, max_results=25, include_all_states=include_all_states)
         except ValueError:
             raise ValueError('The key "{}" does not correspond to the latest build result'.format(plan_key))
 

--- a/atlassian/bamboo.py
+++ b/atlassian/bamboo.py
@@ -94,7 +94,7 @@ class Bamboo(AtlassianRestAPI):
                                    elements_key='plans', element_key='plan')
 
     def results(self, project_key=None, plan_key=None, job_key=None, build_number=None, expand=None, favourite=False,
-                clover_enabled=False, issue_key=None, label=None, start_index=0, max_results=25):
+                clover_enabled=False, issue_key=None, label=None, start_index=0, max_results=25, include_all_states=False):
         """
         Get results as generic method
         :param project_key:
@@ -122,6 +122,8 @@ class Bamboo(AtlassianRestAPI):
         params = {}
         if issue_key:
             params['issueKey'] = issue_key
+        if include_all_states:
+            params['includeAllStates'] = include_all_states
         return self.base_list_call(resource, expand=expand, favourite=favourite, clover_enabled=clover_enabled,
                                    start_index=start_index, max_results=max_results,
                                    elements_key='results', element_key='result', label=label, **params)

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -364,19 +364,22 @@ class Confluence(AtlassianRestAPI):
             data['ancestors'] = [{'type': type, 'id': parent_id}]
         return self.post(url, data=data)
 
-    def get_all_spaces(self, start=0, limit=500):
+    def get_all_spaces(self, start=0, limit=500, expand=None):
         """
         Get all spaces with provided limit
         :param start: OPTIONAL: The start point of the collection to return. Default: None (0).
         :param limit: OPTIONAL: The limit of the number of pages to return, this may be restricted by
                             fixed system limits. Default: 500
+        :param expand: OPTIONAL: additional info, e.g. metadata, icon, description, homepage
         """
         url = 'rest/api/space'
         params = {}
-        if limit:
-            params['limit'] = limit
         if start:
             params['start'] = start
+        if limit:
+            params['limit'] = limit
+        if expand:
+            params['expand'] = expand
         return (self.get(url, params=params) or {}).get('results')
 
     def add_comment(self, page_id, text):


### PR DESCRIPTION
The API supports specifying a version for the page to return, but this python package does currently not support it.

This commit adds it to both `get_page_by_title` and `get_page_by_id`.